### PR TITLE
All logs to stdout, all the time.  File logs if anything should simpl…

### DIFF
--- a/src/main/resources/log4j.xml
+++ b/src/main/resources/log4j.xml
@@ -7,26 +7,31 @@
 		<Console name="Console" target="SYSTEM_OUT">
 		   <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
 		</Console>
-        <RollingFile name="hubEmailLogger" fileName="${log4j:configParentLocation}/../logs/${logFilePrefix}.log" filePattern="${log4j:configParentLocation}/../logs/$${date:yyyy-MM}/${logFilePrefix}%d{MM-dd-yyyy}-%i.log.gz">
-           <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
-           <Policies>
-              <OnStartupTriggeringPolicy/>
-              <SizeBasedTriggeringPolicy size="512MB"/>
-           </Policies>
-           <DefaultRolloverStrategy max="10">
-                <Delete basePath="${log4j:configParentLocation}/../logs" maxDepth="2">
-                  <IfFileName glob="*/${logFilePrefix}*.log.gz"/>
-                  <IfLastModified age="90d"/>
-                </Delete>
-           </DefaultRolloverStrategy>
-        </RollingFile>
+
+    <RollingFile name="hubEmailLogger" fileName="${log4j:configParentLocation}/../logs/${logFilePrefix}.log" filePattern="${log4j:configParentLocation}/../logs/$${date:yyyy-MM}/${logFilePrefix}%d{MM-dd-yyyy}-%i.log.gz">
+       <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+       <Policies>
+          <OnStartupTriggeringPolicy/>
+          <SizeBasedTriggeringPolicy size="512MB"/>
+       </Policies>
+       <DefaultRolloverStrategy max="10">
+            <Delete basePath="${log4j:configParentLocation}/../logs" maxDepth="2">
+              <IfFileName glob="*/${logFilePrefix}*.log.gz"/>
+              <IfLastModified age="90d"/>
+            </Delete>
+       </DefaultRolloverStrategy>
+    </RollingFile>
+
 	</Appenders>
 	<Loggers>
-		<Root level="error">
-		  <AppenderRef ref="hubEmailLogger"/>
+
+		<Root>
+		  <AppenderRef ref="Console"/>
 		</Root>
+
 		<Logger name="com.blackducksoftware.integration" level="info" additivity="false">
-		  <AppenderRef ref="hubEmailLogger"/>
+		  <AppenderRef ref="Console"/>
 		</Logger>
+
 	</Loggers>
 </Configuration>


### PR DESCRIPTION
This simplifies the logging so that everything hits stdout, which is the simplest way to make sure people using fluent or whatever distributed logscraper they need will work.  Also paves way for just integrating w/ the hub's filebeat aggregation .

```
➜  hub-email-extension git:(tarfix) docker run -ti b1a017e6060f
Attempting to import Hub Certificate


keytool error: java.lang.Exception: Alias <publichubwebserver> does not exist
keytool error: java.lang.Exception: Input not an X.509 certificate
Unable to add the certificate. Please try to import the certificate manually.
17:41:10.196 [main] INFO  com.blackducksoftware.integration.email.EmailEngine - Extension ID - com.blackducksoftware.integ
ration.email.email-extension.1.3.1-SNAPSHOT
17:41:10.269 [main] INFO  com.blackducksoftware.integration.email.EmailEngine - Extension Base URL: http://322c4233dbd5:55
000
17:41:10.280 [main] INFO  com.blackducksoftware.integration.email.extension.server.oauth.OAuthConfigManager - Loading OAUT
H configuration...
17:41:10.281 [main] INFO  com.blackducksoftware.integration.email.extension.server.oauth.OAuthConfigManager - Property fil
e location: /blackduck-extensions-config-volume/oauth.properties
17:41:10.281 [main] ERROR com.blackducksoftware.integration.email.extension.server.oauth.OAuthConfigManager - Could not lo
ad properties file.  OAUTH client will need to be Authorized
17:41:10.287 [main] INFO  com.blackducksoftware.integration.email.EmailEngine - Proxy Host          =
```